### PR TITLE
Attrs through fragments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,7 @@
 
 ## Added
 
-## Fixed
-
-## Changed
+- Support attributes when using a top-level fragment in a rendering function
 
 # 0.4.34 (2022-01-25 / df056c8)
 

--- a/README.md
+++ b/README.md
@@ -537,31 +537,44 @@ when using in Hiccup: the first argument, if it's a map, is treated as a map of
 HTML attributes, any following arguments are treated as children.
 
 When you supply your own render function this behavior changes. All arguments
-are passed to the render function to determine the children of the styled
-component. If the first argument is a map, then the `:class`, `:id`, and
-`:style` elements are added to the outer component (they are still passed to the
-render function as well).
+are passed to the render function, which then determines the element's
+attributes and children.
 
-The rationale is that when using a styled component in your Hiccup, it should be
-straightforward to add an extra class or inline styling to the component. We
-don't want to break that use case. But we don't want to treat the map in the
-first argument as only consisting of HTML attributes in this case, since you may
-use that map to pass arbitrary values to the render function. So we lift out
-`:class`, `:id` and `:style`, and ignore the rest.
+To set custom attributes on the outer element from inside the render function,
+you use a properties map together with a fragment `:<>` identifier:
 
 ```clojure
-(o/defstyled videos :section
-  ([{:keys [videos]}]
-   (into [:<>] (map #(do [video %]) videos))))
+(o/defstyled my-compo :div
+ ([props]
+  [:<> {:title "hello"} "hello!"]))
 ```
+
+If you pass a `:class` here it will get added to the class that Ornament
+generates for the component.
+
+When using a component that has a custom render function, you can set attributes
+by using the special `:lambdaisland.ornament/attrs` keyword.
 
 ```clojure
-[videos {:videos (fetch-videos) :id "main-listing"}]
+[my-compo {:regular-prop 123 ::o/attrs {:title "heyo"}}]
 ```
 
-It is still possible to set extra HTML attributes on the component in this case,
-but it has to be done from *inside the render function*, through metadata on the
-return value.
+Any `:class` or `:style` attributes passed in this way will be added to any
+classes or styles set inside the render function with `:<>`. Optionally for
+`:class` and `:style` you can replace the values instead of appending by adding
+a `^:replace` metadata on the vector / map.
+
+```clojure
+[my-compo {::o/attrs {:class ^:replace ["one-class" "other-class"]
+                      :style {:text-color "blue"}}}]
+```
+
+In previous versions we supported `:class`, `:id` and `:style` at the top of the
+properties map, but that's no longer the case.
+
+There's an additional mechanic for setting attributes from inside the
+render-function, through metadata on the return value, but it is considered
+deprecated, since it's superseded by `[:<> {,,,attrs,,,}]`.
 
 ```clojure
 (o/defstyled nav-link :a

--- a/bb.edn
+++ b/bb.edn
@@ -1,3 +1,3 @@
 {:deps
  {lambdaisland/open-source {:git/url "https://github.com/lambdaisland/open-source"
-                            :git/sha "835e8f001659ed07e5835a554b99828331a88e8d"}}}
+                            :git/sha "cf0d95c7443f968377b82bc6e42b64ee27ba438f"}}}

--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,7 @@
 
  :deps
  {garden/garden         {:mvn/version "1.3.10"}
-  girouette/girouette   {:mvn/version "0.0.6"}
+  girouette/girouette   {:mvn/version "0.0.7"}
   meta-merge/meta-merge {:mvn/version "1.0.0"}}
 
  :aliases
@@ -25,7 +25,7 @@
                  com.lambdaisland/glogi {:mvn/version "1.1.144"}
                  ;; for lambdaisland.hiccup and lambdaisland.thicc, used in testing
                  lambdaisland/webstuff {:git/url "https://github.com/lambdaisland/webstuff"
-                                        :git/sha "fc4e2b7e41dd4e3db9a2778b9c69d92148d0549c"
+                                        :git/sha "5d5669e7f7829c65fdd00b19ef826565ce41b7ea"
                                         #_#_:local/root "/home/arne/github/lambdaisland/webstuff"}}}
 
   :cssparser

--- a/notebooks/attributes_and_properties.clj
+++ b/notebooks/attributes_and_properties.clj
@@ -1,0 +1,188 @@
+(ns notebooks.attributes-and-properties
+  (:require
+   [lambdaisland.ornament :as o]
+   [lambdaisland.ornament.clerk-util :refer [inline-styles
+                                             render
+                                             expand]]))
+
+;; # Attributes and Properties
+
+;; When dealing with Ornament components it's important to understand the
+;; distinction between "attributes" and "properties".
+
+;;; ## Attributes
+
+;; Attributes are a concept from HTML, they are the key-value pairs you provide
+;; to HTML elements in your markup.
+
+;; ```html
+;; <a href="//example.com" title="Example">Go to Example</a>
+;; ```
+
+;; In this example `href` and `title` are attributes.
+
+;; When you define a plain Ornament component, one that doesn't have a custom
+;; render function, then you can pass in attributes by providing a map as the
+;; first argument, just like you would do in plain Hiccup.
+
+;; Define components
+
+(o/defstyled strong-link :a
+  {:font-weight 1000
+   :border "1px solid #999"})
+
+[:a {:href "https://github.com/lambdaisland/open-source"}
+ "Check out our open source offerings!"]
+
+(expand
+ [strong-link
+  {:href "https://github.com/lambdaisland/open-source"}
+  "Check out our open source offerings!"])
+
+;; You can see that these two Hiccup forms are basically equivalent, except that
+;; in the case of `strong-link` an extra class is added to the `class`
+;; attribute.
+
+;; ## Properties
+
+;; When defininig components through a render function, as is common in
+;; React/Reagent, you can also pass a map as the first argument. These are
+;; called "properties" or (in React especially) as "props".
+
+;; It's up to the component (the render function) to do something with these.
+
+(defn user-list [{:keys [users] :as props}]
+  [:ul
+   (for [{:keys [name]} users]
+     [:li name])])
+
+(render
+ [user-list {:users [{:name "Arne"}
+                     {:name "Felipe"}]}])
+
+;; The same is true for Ornament components that contain their own render
+;; function.
+
+(o/defstyled styled-user-list :ul
+  [:li {:list-style "square"}]
+  ([{:keys [users] :as props}]
+   (for [{:keys [name]} users]
+     [:li name])))
+
+(render
+ [styled-user-list {:users [{:name "Arne"}
+                            {:name "Felipe"}]}])
+
+;; ## Setting Attributes on Styled Components
+
+;; But what if we still want to set certain attributes on this `:ul`, perhaps we
+;; want to indicate that this element is in a different language using the
+;; `lang` attribute.
+
+;; Generally this is the responsibility of the component itself, it can return a
+;; fragment (`:<>`), inclduding an attributes map.
+
+
+(o/defstyled name-list-de :ul
+  [:li {:list-style "square"}]
+  ([{:keys [users] :as props}]
+   [:<> {:lang "de"}
+    (for [{:keys [name]} users]
+      [:li name])]))
+
+(expand
+ [name-list-de {:users [{:name "Goethe"}
+                        {:name "Freud"}]}])
+
+
+;; So now we've added a `lang` attribute inside the component. You can ignore the
+;; extra attributes here like `:col` and `:row`, they are a consequence of how
+;; Clerk renders things, combined with the fact that we support a legacy syntax
+;; where the attributes are provided as metadata on the result of the render
+;; function.
+
+;; The component could even take a `lang` property, and pass that on as a `lang`
+;; attribute, so that you can decide to set the language at the point where you
+;; are using this component.
+
+;; However Ornament also supports a special property,
+;; `:lambdaisland.ornament/attrs`, which will get merged in with the other
+;; attributes.
+
+(expand
+ [name-list-de {:users [{:name "Goethe"}
+                        {:name "Freud"}]
+                ::o/attrs {:title "German Philosophers"}}])
+
+;; These `::o/attrs` will take precedence over attributes set inside the
+;; component. So our component with `lang=de` could be used for a different
+;; language as well. The value inside the component is the default, but can be
+;; overruled when using the components.
+
+(expand
+ [name-list-de {:users [{:name "René Magritte"}
+                        {:name "James Ensor"}]
+                ::o/attrs {:lang "nl"
+                           :title "Belgische Kunstenaars"}}])
+
+;; When merging attributes like this `:class` and `:style` are handled special.
+;; Classes are additive, you get both the classes defined inside the component,
+;; the ones passed in through `::o/attrs`, and the special ornament class that
+;; gets generated to link this component to its styles. You can use either
+;; strings or vectors of strings as the `class` attribute.
+
+;; `:style` attributes are merged (assuming they are maps).
+
+(o/defstyled name-list-klz :ul
+  [:li {:list-style "square"}]
+  ([{:keys [users] :as props}]
+   [:<> {:class "some-class"
+         :style {:background-color "red"}}
+    (for [{:keys [name]} users]
+      [:li name])]))
+
+(expand
+ [name-list-klz {:users [{:name "John"}]
+                 ::o/attrs
+                 {:class "other-class"
+                  :style {:text-color "blue"}}}])
+
+;; Class attribute as a vector:
+
+(expand
+ [name-list-klz {:users [{:name "John"}]
+                 ::o/attrs {:class ["one-class" "other-class"]
+                            :style {:text-color "blue"}}}])
+
+;; For both `:class` and `:style` you can get the regular merge behavior back,
+;; where the `::o/attrs` value completely replaces the default value specified
+;; in the component, by adding a `^:replace` metadata on the vector or map.
+
+(expand
+ [name-list-klz {:users [{:name "John"}]
+                 ::o/attrs {:class ^:replace ["one-class" "other-class"]
+                            :style ^:replace {:text-color "blue"}}}])
+
+;; ## Conclusion
+
+;; While we were working on Ornament, and trying it out on various projects, we
+;; found we wanted a large degree of flexibility for setting attributes, either
+;; from within the component, or from without.
+
+;; We wanted to stay fairly close to how things work in plain Hiccup, as well as
+;; in Reagent, so people can largely rely on their existing mental models.
+
+;; At the same time we had to reconcile some differences with how plain HTML
+;; elements work in Hiccup, vs how rendered components work. We went through a
+;; few iterations, and finally realized that by making a clear distinction
+;; between attributes and properties we could define behavior that is
+;; consistent, explicit, and intuitive, while avoiding "magic" and a
+;; proliferation of special cases.
+
+;; While there are some particulars to be aware of, we hope the result will
+;; generally be found to be intuitive, and to yield code that does not present
+;; undue surprises to the reader.
+
+^{:nextjournal.clerk/no-cache true
+  :nextjournal.clerk/visibility #{:fold}}
+(inline-styles)

--- a/notebooks/demo.clj
+++ b/notebooks/demo.clj
@@ -1,7 +1,7 @@
 (ns demo
-  (:require [lambdaisland.ornament :as o]
-            [nextjournal.clerk :as clerk]
-            [lambdaisland.hiccup :as hiccup]))
+  (:require [lambdaisland.hiccup :as hiccup]
+            [lambdaisland.ornament :as o]
+            [nextjournal.clerk :as clerk]))
 
 ;; # A Small Demonstration of Ornament
 

--- a/notebooks/template.clj
+++ b/notebooks/template.clj
@@ -1,0 +1,23 @@
+(ns notebooks.template
+  (:require
+   [lambdaisland.ornament :as o]
+   [lambdaisland.ornament.clerk-util :refer [inline-styles render]]))
+
+;; # Ornament Notebook Template
+
+;; Define components
+
+(o/defstyled strong-link :a
+  {:font-weight 1000})
+
+;; Render them with Hiccup
+
+(render
+ [strong-link {:href "https://github.com/lambdaisland/open-source"}
+  "Check out our open source offerings!"])
+
+;; Inline our styles last, so that this happens after all `defstyled`s are
+;; defined.
+
+^{:nextjournal.clerk/no-cache true}
+(inline-styles)

--- a/src/lambdaisland/ornament/clerk_util.clj
+++ b/src/lambdaisland/ornament/clerk_util.clj
@@ -1,0 +1,27 @@
+(ns lambdaisland.ornament.clerk-util
+  (:require [lambdaisland.hiccup :as hiccup]
+            [lambdaisland.ornament :as o]
+            [nextjournal.clerk :as clerk]))
+
+(defn render
+  "Render hiccup containing Ornament component references inside a Clerk
+  notebook."
+  [h]
+  (clerk/html (hiccup/render h {:doctype? false})))
+
+(defn inline-styles
+  "Inject our CSS styles into the Clerk document, so components render correctly.
+  Add this at the end of your notebook, and add a 'no-cache' marker.
+
+  ```
+  ^{::clerk/no-cache true}
+  (util/inline-styles)
+  ```
+  "
+  []
+  (render [:style (o/defined-styles)]))
+
+(defn expand
+  "Expand a hiccup form with an ornament component to plain hiccup elements. Does not recurse."
+  [[component & args]]
+  (o/as-hiccup component args))

--- a/test/lambdaisland/ornament_test.cljc
+++ b/test/lambdaisland/ornament_test.cljc
@@ -282,14 +282,19 @@
 
        ;; Deal with the fact that the registry is populated at compile time
        (eval
-        `(o/defstyled ~'my-styles :div
-           {:color "red"}))
+        `(do
+           (in-ns '~(symbol (namespace `_)))
+           (o/defstyled ~'my-styles :div
+             {:color "red"})
+           (o/defstyled ~'more-styles :span
+             :rounded-xl)))
 
-       (eval
-        `(o/defstyled ~'more-styles :span
-           :rounded-xl))
-
-       (is (= ".user__my_styles{color:red}\n.user__more_styles{border-radius:.75rem}"
+       (is (= ".ot__my_styles{color:red}\n.ot__more_styles{border-radius:.75rem}"
               (o/defined-styles)))
 
        (reset! o/registry reg))))
+
+(comment
+  (require 'kaocha.repl)
+  (kaocha.repl/run)
+  )

--- a/test/lambdaisland/ornament_test.cljc
+++ b/test/lambdaisland/ornament_test.cljc
@@ -116,6 +116,12 @@
          :style {:color "blue"}}
     "hello, " person]))
 
+(o/defstyled attrs-legacy :div
+  ([{:keys [person]}]
+   ^{:class "extra-class"
+     :style {:color "blue"}}
+   [:<> "hello, " person]))
+
 #?(:clj
    (deftest css-test
      (is (= ".ot__simple{color:#fff}"
@@ -210,6 +216,9 @@
                                           :style {:background-color "rebeccapurple"}}}]
     #?(:clj "<div class=\"ot__attrs_in_fragment_styled extra-class extra2\" style=\"color: blue;\n  background-color: rebeccapurple;\">hello, Finn</div>"
        :cljs "<div class=\"ot__attrs_in_fragment_styled extra-class extra2\" style=\"color: blue; background-color: rebeccapurple;\">hello, Finn</div>")
+
+    [attrs-legacy {:person "Arne"}]
+    "<div class=\"ot__attrs_legacy extra-class\" style=\"color: blue;\">hello, Arne</div>"
 
     ;; ClojureScript bug, this does not currently work:
     ;; https://ask.clojure.org/index.php/11514/functions-with-metadata-can-not-take-more-than-20-arguments

--- a/test/lambdaisland/ornament_test.cljc
+++ b/test/lambdaisland/ornament_test.cljc
@@ -100,6 +100,22 @@
   ;; Girouette recognizes.
   [:ul :ol {:background-color "blue"}])
 
+(o/defstyled attrs-in-fragment :div
+  ([children]
+   [:<> {:lang "nl"}
+    children]))
+
+(o/defstyled attrs-in-fragment-props :div
+  ([{:keys [person]}]
+   [:<> {:lang "nl"}
+    "hello, " person]))
+
+(o/defstyled attrs-in-fragment-styled :div
+  ([{:keys [person]}]
+   [:<> {:class "extra-class"
+         :style {:color "blue"}}
+    "hello, " person]))
+
 #?(:clj
    (deftest css-test
      (is (= ".ot__simple{color:#fff}"
@@ -142,6 +158,7 @@
      (is (= ".ot__siblings_plain ul,.ot__siblings_plain ol{background-color:blue}"
             (o/css siblings-plain)))))
 
+
 (deftest rendering-test
   (are [hiccup html] (= html (render hiccup))
     [simple]
@@ -167,6 +184,32 @@
 
     [with-body "hello"]
     "<p class=\"ot__with_body\"><strong>hello</strong></p>"
+
+    ;; we're getting inconsistent but equivalent rendering here between clj and
+    ;; cljs. Not ideal, but not a big deal either. Working around with reader
+    ;; conditionals.
+    [attrs-in-fragment "hello"]
+    #?(:clj "<div lang=\"nl\" class=\"ot__attrs_in_fragment\">hello</div>"
+       :cljs "<div class=\"ot__attrs_in_fragment\" lang=\"nl\">hello</div>")
+
+    [attrs-in-fragment-props
+     {:person "Arne"
+      ::o/attrs {:lang "en" :title "greeting"}}]
+    #?(:clj "<div lang=\"en\" title=\"greeting\" class=\"ot__attrs_in_fragment_props\">hello, Arne</div>"
+       :cljs "<div title=\"greeting\" class=\"ot__attrs_in_fragment_props\" lang=\"en\">hello, Arne</div>")
+
+    [attrs-in-fragment-props {:person "Jake"}]
+    #?(:clj "<div lang=\"nl\" class=\"ot__attrs_in_fragment_props\">hello, Jake</div>"
+       :cljs "<div class=\"ot__attrs_in_fragment_props\" lang=\"nl\">hello, Jake</div>")
+
+    [attrs-in-fragment-styled {:person "Finn"}]
+    "<div class=\"ot__attrs_in_fragment_styled extra-class\" style=\"color: blue;\">hello, Finn</div>"
+
+    [attrs-in-fragment-styled {:person "Finn"
+                               ::o/attrs {:class "extra2"
+                                          :style {:background-color "rebeccapurple"}}}]
+    #?(:clj "<div class=\"ot__attrs_in_fragment_styled extra-class extra2\" style=\"color: blue;\n  background-color: rebeccapurple;\">hello, Finn</div>"
+       :cljs "<div class=\"ot__attrs_in_fragment_styled extra-class extra2\" style=\"color: blue; background-color: rebeccapurple;\">hello, Finn</div>")
 
     ;; ClojureScript bug, this does not currently work:
     ;; https://ask.clojure.org/index.php/11514/functions-with-metadata-can-not-take-more-than-20-arguments


### PR DESCRIPTION
Implement setting attributes through fragment syntax

See [the corresponding notebook](https://notebooks.lambdaisland.com/ornament/sha/c1d7195c6f07f44378cb569c080ed2dfb08aa2d7/notebooks/attributes_and_properties.html) for full explanation and examples.

This also means we now expand `:<>` ourselves (when used directly inside a component), so you can now tap into this even if your Hiccup implementation is not aware how to deal with this.

Added a notebook that explains things in details.

Still needs

- [x] tests
- [x] changelog
- [x] readme