### PR TITLE
Fix typo in doc code

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ syntax is supported.)
 
 ```clojure
 ;; Hiccup
-[freebies-link {:href "/episodes/interceptors-concepts} "Freebies"]
+[freebies-link {:href "/episodes/interceptors-concepts"} "Freebies"]
 ```
 
 Which renders as:


### PR DESCRIPTION
I've tried to copy this snipped and my IDE started to complain about an unclosed string.

Thanks for this awesome project BTW \o/

