### PR TITLE
Ornament next

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,13 @@
 - Add `defprop`, for CSS custom properties (aka variables)
 - Add `defutil`, for standalone utility classes
 - Add `import-tokens!`, for importing W3C design token JSON files as properties (as per `defprop`)
+- Allow setting metadata on a child list, useful for reagent/react keys
 
 ## Fixed
 
 - Fix `defined-garden`
 - Use of `defrules` in pure-cljs namespaces
+- Fix implementation of ILookup on cljs
 
 # 1.12.107 (2023-09-27 / 2444e34)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Unreleased
 
+## Changed
+
+- When setting a custom `:ornament/prefix` on the namespace, the separator `__`
+  is no longer implied, to get the same result add `__` to the end of your
+  prefix string.
+
 ## Added
 
 - Support docstrings, they come after the tagname, before any styles or tokens

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## Changed
 
-- When setting a custom `:ornament/prefix` on the namespace, the separator `__`
-  is no longer implied, to get the same result add `__` to the end of your
-  prefix string.
+- [BREAKING] When setting a custom `:ornament/prefix` on the namespace, the
+  separator `__` is no longer implied, to get the same result add `__` to the
+  end of your prefix string.
 
 ## Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 ## Added
 
 - Support docstrings, they come after the tagname, before any styles or tokens
+- If there's only a zero-arg render function (fn-tail), also emit a one-arg
+  version that takes HTML attributes to be merged in.
+- Add `defrules`, for general garden CSS rules
+- Add `defprop`, for CSS custom properties (aka variables)
+- Add `defutil`, for standalone utility classes
+- Add `import-tokens!`, for importing W3C design token JSON files as properties (as per `defprop`)
 
 ## Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 ## Fixed
 
 - Fix `defined-garden`
+- Use of `defrules` in pure-cljs namespaces
 
 # 1.12.107 (2023-09-27 / 2444e34)
 

--- a/README.md
+++ b/README.md
@@ -943,6 +943,21 @@ And get a bullet list which uses bear emojis for the bullets.
 Girouette provides. You can change that by adding a `^:replace` tag (this uses
 meta-merge). e.g. `{:colors ^:replace {...}}`) 
 
+## Babashka compatibility
+
+Unfortunately Ornament is not bb-compatible, and most likely never will be.
+
+Ornament styled components extend the `IFn` interface, babashka only supports
+extending protocols. Extending `IFn` is quite crucial to Ornament's design,
+since this is what allows us to make Hiccup-compatible components, since they
+act as functions.
+
+There are similar issues with libraries we depend on, notably Garden via
+Girouette. Girouette also depends on Instaparse, which is also in its original
+form not bb-compatible.
+
+Making Garden bb-com 
+
 <!-- opencollective -->
 ## Lambda Island Open Source
 

--- a/bb.edn
+++ b/bb.edn
@@ -1,3 +1,3 @@
 {:deps
  {lambdaisland/open-source {:git/url "https://github.com/lambdaisland/open-source"
-                            :git/sha "4cb6231e7df947ee8f5434e7ad48ffd8e273bcf5"}}}
+                            :git/sha "6cb675d2adae284021f8cd94dcfbd078986b39bd"}}}

--- a/bb.edn
+++ b/bb.edn
@@ -1,3 +1,3 @@
 {:deps
  {lambdaisland/open-source {:git/url "https://github.com/lambdaisland/open-source"
-                            :git/sha "2dc2a8ef9978a3fc45e8f524b0e46253caa40fe2"}}}
+                            :git/sha "4cb6231e7df947ee8f5434e7ad48ffd8e273bcf5"}}}

--- a/deps.edn
+++ b/deps.edn
@@ -9,14 +9,13 @@
  :aliases
  {:dev
   {:extra-paths ["dev"]
-   :extra-deps  {djblue/portal               {:mvn/version "0.56.0"}
-                 io.github.nextjournal/clerk {:mvn/version "0.16.1016"}
-                 com.lambdaisland/hiccup     {:mvn/version "0.7.42"} }}
+   :extra-deps  {io.github.nextjournal/clerk {:mvn/version "0.17.1102"}
+                 com.lambdaisland/hiccup     {:mvn/version "0.14.67"} }}
 
   :byo
   {:extra-deps {hawk/hawk                {:mvn/version "0.2.11"}
                 com.lambdaisland/glogi   {:mvn/version "1.3.169"}
-                io.pedestal/pedestal.log {:mvn/version "0.6.4"}}}
+                io.pedestal/pedestal.log {:mvn/version "0.7.2"}}}
 
   :test
   {:extra-paths ["test"]

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:paths ["src" "resources"]
 
  :deps
- {org.clojure/clojure   {:mvn/version "1.11.1"}
+ {org.clojure/clojure   {:mvn/version "1.11.3"}
   garden/garden         {:mvn/version "1.3.10"}
   girouette/girouette   {:mvn/version "0.0.10"}
   meta-merge/meta-merge {:mvn/version "1.0.0"}}
@@ -9,24 +9,24 @@
  :aliases
  {:dev
   {:extra-paths ["dev"]
-   :extra-deps  {djblue/portal {:mvn/version "0.46.0"}
-                 io.github.nextjournal/clerk {:mvn/version "0.14.919"}
-                 com.lambdaisland/hiccup {:mvn/version "0.0.33"} }}
+   :extra-deps  {djblue/portal {:mvn/version "0.56.0"}
+                 io.github.nextjournal/clerk {:mvn/version "0.16.1016"}
+                 com.lambdaisland/hiccup {:mvn/version "0.7.42"} }}
 
   :byo
   {:extra-deps {hawk/hawk {:mvn/version "0.2.11"}
                 com.lambdaisland/glogi {:mvn/version "1.3.169"}
-                io.pedestal/pedestal.log {:mvn/version "0.6.0"}}}
+                io.pedestal/pedestal.log {:mvn/version "0.6.4"}}}
 
   :test
   {:extra-paths ["test"]
-   :extra-deps  {lambdaisland/kaocha {:mvn/version "1.86.1355"}
+   :extra-deps  {lambdaisland/kaocha {:mvn/version "1.91.1392"}
                  lambdaisland/kaocha-cljs {:mvn/version "1.5.154"}
-                 org.clojure/clojurescript {:mvn/version "1.11.60"}
+                 org.clojure/clojurescript {:mvn/version "1.11.132"}
                  com.lambdaisland/glogi {:mvn/version "1.3.169"}
                  ;; for lambdaisland.hiccup and lambdaisland.thicc, used in testing
                  lambdaisland/webstuff {:git/url "https://github.com/lambdaisland/webstuff"
-                                        :git/sha "78033fbda228c5e2fc0745619e7830b005407156"
+                                        :git/sha "f3ae2a2d41a4335d3da1757a3a21aa1dd1125eb1"
                                         #_#_:local/root "/home/arne/github/lambdaisland/webstuff"}}}
 
   :cssparser

--- a/deps.edn
+++ b/deps.edn
@@ -1,39 +1,39 @@
 {:paths ["src" "resources"]
 
  :deps
- {org.clojure/clojure   {:mvn/version "1.11.3"}
-  garden/garden         {:mvn/version "1.3.10"}
-  girouette/girouette   {:mvn/version "0.0.10"}
-  meta-merge/meta-merge {:mvn/version "1.0.0"}}
+ {org.clojure/clojure     {:mvn/version "1.12.0"}
+  com.lambdaisland/garden {:mvn/version "1.6.585"}
+  girouette/girouette     {:mvn/version "0.0.10"}
+  meta-merge/meta-merge   {:mvn/version "1.0.0"}}
 
  :aliases
  {:dev
   {:extra-paths ["dev"]
-   :extra-deps  {djblue/portal {:mvn/version "0.56.0"}
+   :extra-deps  {djblue/portal               {:mvn/version "0.56.0"}
                  io.github.nextjournal/clerk {:mvn/version "0.16.1016"}
-                 com.lambdaisland/hiccup {:mvn/version "0.7.42"} }}
+                 com.lambdaisland/hiccup     {:mvn/version "0.7.42"} }}
 
   :byo
-  {:extra-deps {hawk/hawk {:mvn/version "0.2.11"}
-                com.lambdaisland/glogi {:mvn/version "1.3.169"}
+  {:extra-deps {hawk/hawk                {:mvn/version "0.2.11"}
+                com.lambdaisland/glogi   {:mvn/version "1.3.169"}
                 io.pedestal/pedestal.log {:mvn/version "0.6.4"}}}
 
   :test
   {:extra-paths ["test"]
-   :extra-deps  {lambdaisland/kaocha {:mvn/version "1.91.1392"}
-                 lambdaisland/kaocha-cljs {:mvn/version "1.5.154"}
+   :extra-deps  {lambdaisland/kaocha       {:mvn/version "1.91.1392"}
+                 lambdaisland/kaocha-cljs  {:mvn/version "1.5.154"}
                  org.clojure/clojurescript {:mvn/version "1.11.132"}
-                 com.lambdaisland/glogi {:mvn/version "1.3.169"}
+                 com.lambdaisland/glogi    {:mvn/version "1.3.169"}
                  ;; for lambdaisland.hiccup and lambdaisland.thicc, used in testing
-                 lambdaisland/webstuff {:git/url "https://github.com/lambdaisland/webstuff"
-                                        :git/sha "f3ae2a2d41a4335d3da1757a3a21aa1dd1125eb1"
-                                        #_#_:local/root "/home/arne/github/lambdaisland/webstuff"}}}
+                 lambdaisland/webstuff     {:git/url        "https://github.com/lambdaisland/webstuff"
+                                            :git/sha        "f3ae2a2d41a4335d3da1757a3a21aa1dd1125eb1"
+                                            #_#_:local/root "/home/arne/github/lambdaisland/webstuff"}}}
 
   :cssparser
   {:extra-deps {net.sourceforge.cssparser/cssparser {:mvn/version "0.9.30"}}}
 
   :nextjournal/clerk
-  {:exec-fn nextjournal.clerk/build!
-   :exec-args {:paths ["notebooks/demo.clj"
-                       "notebooks/attributes_and_properties.clj"]}
+  {:exec-fn                   nextjournal.clerk/build!
+   :exec-args                 {:paths ["notebooks/demo.clj"
+                                       "notebooks/attributes_and_properties.clj"]}
    :nextjournal.clerk/aliases [:dev]}}}

--- a/notebooks/demo.clj
+++ b/notebooks/demo.clj
@@ -1,7 +1,8 @@
 (ns demo
-  (:require [lambdaisland.hiccup :as hiccup]
-            [lambdaisland.ornament :as o]
-            [nextjournal.clerk :as clerk]))
+  (:require
+   [lambdaisland.hiccup :as hiccup]
+   [lambdaisland.ornament :as o]
+   [nextjournal.clerk :as clerk]))
 
 ;; # A Small Demonstration of Ornament
 

--- a/notebooks/ornament_next.clj
+++ b/notebooks/ornament_next.clj
@@ -1,0 +1,85 @@
+(ns ornament-next
+  (:require
+   [lambdaisland.hiccup :as hiccup]
+   [lambdaisland.ornament :as o]
+   [nextjournal.clerk :as clerk]))
+
+(reset! o/registry {})
+(reset! o/rules-registry {})
+(reset! o/props-registry {})
+
+;; Original Ornament was all about styled components, meaning we put
+;; Garden-syntax CSS inside your components to style them. Later on we added
+;; support for Girouette, which means you can use shorthand tags similar to
+;; Tailwind utility classes to define your style rules.
+
+;; This is great, but it's not the full story. Ornament Next gives you several
+;; news ways to define and structure your styles, and better dev-time
+;; affordances.
+
+;; Here's a regular old Ornament styled component, except that it now sports a
+;; docstring. The docstring that actually gets set on the var also contains the
+;; compiled CSS, and we set `:arglists`, so you can see how to use it aas a
+;; component in your Hiccup.
+
+(o/defstyled user-form :form
+  "Form used on the profile page"
+  :mx-3)
+
+(:arglists (meta #'user-form))
+(:doc (meta #'user-form))
+
+;; The new macros that follow all support docstrings.
+
+;; ## defrules
+
+;; The most basic one is `defrules`, which lets you define plain Garden CSS
+;; rules that get prepended to your Ornament styles. Realistically there are
+;; always still things you define globally, and you shouldn't have to jump
+;; through extra hoops to do so. `defrules` still takes a name and optionally a
+;; docstring, so you can split up your styles and document them.
+
+(o/defrules my-style
+  "Some common defaults"
+  [:* {:box-sizing "border-box"}]
+  [:form :mx-2])
+
+;; ## defutil
+
+;; There's now also `defutil` for defining utility classes. This is in a way
+;; similar, in that it defines global CSS, but you get a handle onto something
+;; that you can use like a CSS class.
+
+(o/defutil square
+  "Ensure the element has the same width and height."
+  {:aspect-ratio 1})
+
+;; This creates a utility class in your CSS. Note that it's namespaced, like all
+;; classes in Ornament, to be collision free.
+
+(o/defined-styles)
+
+;; You can now use this in multiple ways, the simplest is direcly in hiccup.
+
+(hiccup/render [:img {:class [square]}])
+
+;; You can also use it in styled components, to pull those additional style
+;; rules into the CSS of the component.
+
+(o/defstyled avatar :img
+  "A square avatar"
+  square)
+
+(o/css avatar)
+
+;; ## defprop
+
+;; Modern CSS heavily leans on CSS custom properties, also known as variables.
+;; These are especially useful for defining design tokens.
+
+;; These can be defined with or without
+
+(o/defprop without-default)
+(o/defprop color-primary "hsla(201, 100%, 50%, 1)")
+
+(o/defined-styles)

--- a/notebooks/ornament_next.clj
+++ b/notebooks/ornament_next.clj
@@ -75,6 +75,7 @@
 
 (hiccup/render [:img {:class [square]}])
 
+
 ;; You can also use it in styled components, to pull those additional style
 ;; rules into the CSS of the component.
 
@@ -91,7 +92,10 @@
 
 ;; These can be defined with or without
 
-(o/defprop without-default)
-(o/defprop color-primary "hsla(201, 100%, 50%, 1)")
+(o/defprop --without-default)
+(o/defprop --color-primary "hsla(201, 100%, 50%, 1)")
+
+
+(hiccup/render [:img {:style {:backgroun-color --color-primary}}])
 
 (o/defined-styles)

--- a/notebooks/ornament_next.clj
+++ b/notebooks/ornament_next.clj
@@ -44,6 +44,18 @@
   [:* {:box-sizing "border-box"}]
   [:form :mx-2])
 
+;; Ornament features like tailwing utilities or referencing components work here
+;; too.
+
+(o/defstyled menu :nav
+  :hidden)
+
+(o/defrules toggle-menu
+  [:body.menu-open
+   [menu :block]])
+
+(o/defined-garden)
+
 ;; ## defutil
 
 ;; There's now also `defutil` for defining utility classes. This is in a way

--- a/repl_sessions/poke.clj
+++ b/repl_sessions/poke.clj
@@ -1,13 +1,71 @@
 (ns poke
-  (:require [lambdaisland.ornament :as o]))
+  (:require
+   [lambdaisland.ornament :as o]
+   [lambdaisland.hiccup :as hiccup]))
 
+(set! *print-namespace-maps* false)
 
 (o/defstyled freebies-link :a
   {:font-size "1rem"
    :color "#cff9cf"
    :text-decoration "underline"})
 
+(o/rules freebies-link)
+
 (freebies-link {:href "/episodes/interceptors-concepts"} "hello")
 
 [:a {:class ["poke__freebies_link"]
      :href "/episodes/interceptors-concepts"} "hello"]
+
+(o/defstyled foo :div
+  {:margin size-2})
+(o/css foo)
+(o/defprop size-2 "2rem")
+(o/defrules main-styles
+  "Main application styles"
+  [:.link {:color "blue"}]
+  [:.link:visited {:color "purple"}]
+  [:main
+   [:.container {:width size-2}]])
+
+(garden.compiler/expand size-2)
+main-styles
+(o/defutil square {:aspect-ratio 1})
+o/props-registry
+(o/defined-garden)
+(o/defined-styles)
+(o/defstyled avatar :img
+  {size-2 size-2}
+  #_#_(garden.stylesheet/at-media {"print" true} [:& {:color "blue"}])
+  (garden.stylesheet/at-keyframes "myanim" [:100% {:height "10px"}])
+  )
+(#'garden.compiler/expand-stylesheet {size-2 size-2})
+(garden.compiler/compile-css [:& {size-2 size-2}])
+
+(hiccup/render [avatar {:style {size-2 "3rem"}}])
+(map class (o/process-rules
+            (o/rules avatar)))
+duration |
+easing-function |
+delay |
+iteration-count |
+direction |
+fill-mode |
+play-state |
+name
+
+(o/defanimation pulse
+  :duration
+  "2s"
+  :keyframes
+  ["0%" "100%" {:opacity 1}]
+  ["50%" {:opacity 0.5}])
+
+(o/css avatar)
+
+*e
+(o/defined-styles)
+
+(hiccup/render [:div {:class [square]}])
+
+()

--- a/src/lambdaisland/ornament.cljc
+++ b/src/lambdaisland/ornament.cljc
@@ -1,6 +1,5 @@
 (ns lambdaisland.ornament
   "CSS-in-clj(s)"
-<<<<<<< Updated upstream
   #?@
   (:clj
    [(:require
@@ -20,40 +19,6 @@
      [meta-merge.core :as meta-merge])]
    :cljs
    [(:require [clojure.string :as str] [garden.util :as gu])]))
-||||||| Stash base
-  (:require [clojure.string :as str]
-            [meta-merge.core :as meta-merge]
-            #?@(:clj [[clojure.walk :as walk]
-                      [garden.compiler :as gc]
-                      [garden.core :as garden]
-                      [garden.color :as gcolor]
-                      [garden.types :as gt]
-                      [garden.stylesheet :as gs]
-                      [girouette.version :as girouette-version]
-                      [girouette.tw.core :as girouette]
-                      [girouette.tw.preflight :as girouette-preflight]
-                      [girouette.tw.typography :as girouette-typography]
-                      [girouette.tw.color :as girouette-color]
-                      [girouette.tw.default-api :as girouette-default]]))
-  #?(:cljs
-     (:require-macros [lambdaisland.ornament :refer [defstyled]])))
-=======
-  (:require [clojure.string :as str]
-            [meta-merge.core :as meta-merge]
-            #?@(:clj [[clojure.walk :as walk]
-                      [garden.compiler :as gc]
-                      [garden.core :as garden]
-                      [garden.color :as gcolor]
-                      [garden.types :as gt]
-                      [garden.stylesheet :as gs]
-                      [girouette.version :as girouette-version]
-                      [girouette.tw.core :as girouette]
-                      [girouette.tw.preflight :as girouette-preflight]
-                      [girouette.tw.typography :as girouette-typography]
-                      [girouette.tw.color :as girouette-color]]))
-  #?(:cljs
-     (:require-macros [lambdaisland.ornament :refer [defstyled]])))
->>>>>>> Stashed changes
 
 #?(:clj
    (defonce ^{:doc "Registry of styled components
@@ -800,7 +765,7 @@
            rules  (process-rules
                    (eval `(do
                             (in-ns '~(ns-name *ns*))
-                            ~(cons 'list rules))))]
+                            ~(cons 'clojure.core/list rules))))]
        (register! rules-registry varsym {:rules rules})
        (when-not (:ns &env)
          `(def ~rules-name ~(render-docstring docstring rules) '~rules)))))
@@ -1008,4 +973,3 @@
        (sort-by :index)
        (mapcat :rules)
        process-rules))
-

--- a/src/lambdaisland/ornament.cljc
+++ b/src/lambdaisland/ornament.cljc
@@ -904,11 +904,12 @@
   Optionally the Tailwind preflight (reset) stylesheet can be prepended using
   `:preflight? true`. This defaults to Tailwind v2 (as provided by Girouette).
   Version 3 is available with `:tw-version 3`"
-     [& [{:keys [preflight? tw-version]
+     [& [{:keys [preflight? tw-version compress?]
           :or {preflight? false
-               tw-version 2}}]]
+               tw-version 2
+               compress? true}}]]
      (gc/compile-css
-      {:pretty-print? false}
+      {:pretty-print? (not compress?)}
       (cond->> (defined-garden)
         preflight? (concat (case tw-version
                              2 girouette-preflight/preflight-v2_0_3

--- a/src/lambdaisland/ornament.cljc
+++ b/src/lambdaisland/ornament.cljc
@@ -1,5 +1,6 @@
 (ns lambdaisland.ornament
   "CSS-in-clj(s)"
+<<<<<<< Updated upstream
   #?@
   (:clj
    [(:require
@@ -19,6 +20,40 @@
      [meta-merge.core :as meta-merge])]
    :cljs
    [(:require [clojure.string :as str] [garden.util :as gu])]))
+||||||| Stash base
+  (:require [clojure.string :as str]
+            [meta-merge.core :as meta-merge]
+            #?@(:clj [[clojure.walk :as walk]
+                      [garden.compiler :as gc]
+                      [garden.core :as garden]
+                      [garden.color :as gcolor]
+                      [garden.types :as gt]
+                      [garden.stylesheet :as gs]
+                      [girouette.version :as girouette-version]
+                      [girouette.tw.core :as girouette]
+                      [girouette.tw.preflight :as girouette-preflight]
+                      [girouette.tw.typography :as girouette-typography]
+                      [girouette.tw.color :as girouette-color]
+                      [girouette.tw.default-api :as girouette-default]]))
+  #?(:cljs
+     (:require-macros [lambdaisland.ornament :refer [defstyled]])))
+=======
+  (:require [clojure.string :as str]
+            [meta-merge.core :as meta-merge]
+            #?@(:clj [[clojure.walk :as walk]
+                      [garden.compiler :as gc]
+                      [garden.core :as garden]
+                      [garden.color :as gcolor]
+                      [garden.types :as gt]
+                      [garden.stylesheet :as gs]
+                      [girouette.version :as girouette-version]
+                      [girouette.tw.core :as girouette]
+                      [girouette.tw.preflight :as girouette-preflight]
+                      [girouette.tw.typography :as girouette-typography]
+                      [girouette.tw.color :as girouette-color]]))
+  #?(:cljs
+     (:require-macros [lambdaisland.ornament :refer [defstyled]])))
+>>>>>>> Stashed changes
 
 #?(:clj
    (defonce ^{:doc "Registry of styled components
@@ -78,16 +113,18 @@
        (atom nil))
 
      (def default-tokens-v2
-       {:components (-> girouette-default/all-tw-components
-                        (girouette-version/filter-components-by-version [:tw 2]))
-        :colors     girouette-color/tw-v2-colors
-        :fonts      girouette-typography/tw-v2-font-family-map})
+       (delay
+         {:components (-> @(requiring-resolve 'girouette.tw.default-api/all-tw-components)
+                          (girouette-version/filter-components-by-version [:tw 2]))
+          :colors     girouette-color/tw-v2-colors
+          :fonts      girouette-typography/tw-v2-font-family-map}))
 
      (def default-tokens-v3
-       {:components (-> girouette-default/all-tw-components
-                        (girouette-version/filter-components-by-version [:tw 3]))
-        :colors     girouette-color/tw-v3-unified-colors-extended
-        :fonts      girouette-typography/tw-v2-font-family-map})
+       (delay
+         {:components (-> @(requiring-resolve 'girouette.tw.default-api/all-tw-components)
+                          (girouette-version/filter-components-by-version [:tw 3]))
+          :colors     girouette-color/tw-v3-unified-colors-extended
+          :fonts      girouette-typography/tw-v2-font-family-map}))
 
      (def default-tokens default-tokens-v2)
 
@@ -127,8 +164,8 @@
        (let [{:keys [components colors fonts]}
              (meta-merge/meta-merge
               (case tw-version
-                2 default-tokens-v2
-                3 default-tokens-v3)
+                2 @default-tokens-v2
+                3 @default-tokens-v3)
               {:components
                (into (empty components)
                      (map (fn [{:keys [id rules garden] :as c}]

--- a/src/lambdaisland/ornament.cljc
+++ b/src/lambdaisland/ornament.cljc
@@ -790,8 +790,6 @@
          )
        {:type ::prop})))
 
-(clojure.reflect/reflect clojure.lang.ILookup)
-
 #?(:clj
    (defmethod print-method ::prop [p writer]
      (.write writer (lvalue p))))

--- a/src/lambdaisland/ornament.cljc
+++ b/src/lambdaisland/ornament.cljc
@@ -429,7 +429,8 @@
   "Expand an ornament component being called directly with child elements, without
   custom render function."
   [tag css-class children extra-attrs]
-  (let [[tag attrs children :as result]
+  (let [child-meta (meta children)
+        [tag attrs children :as result]
         (if (sequential? children)
           (as-> children $
             (if (= :<> (first $)) (next $) $)
@@ -441,7 +442,10 @@
                           (merge-attrs (meta children) extra-attrs)
                           css-class)]
                     (if (vector? $) (list $) $))))
-          [tag (attr-add-class extra-attrs css-class) children])]
+          [tag (attr-add-class extra-attrs css-class) children])
+        result (if child-meta
+                 (with-meta result child-meta)
+                 result)]
     (if (= :<> (first children))
       (recur tag nil children attrs)
       result)))
@@ -832,9 +836,8 @@
          (lvalue [_] (str "--" (name prop-name)))
          (rvalue [_] (str "var(--" (name prop-name) ")"))
          ILookup
-         (-valAt [this kw] (when (= :default kw) default))
-         (-valAt [this kw fallback] (if (= :default kw) default fallback))
-         )
+         (-lookup [this kw] (when (= :default kw) default))
+         (-lookup [this kw fallback] (if (= :default kw) default fallback)))
        {:type ::prop})))
 
 #?(:clj

--- a/src/lambdaisland/ornament.cljc
+++ b/src/lambdaisland/ornament.cljc
@@ -140,7 +140,7 @@
 
                               :always
                               (update :garden #(comp process-rule %)))))
-                     components)
+                     (flatten components))
                :colors (into (empty colors)
                              (map (juxt (comp name key) val))
                              colors)
@@ -965,9 +965,10 @@
 
 (comment
   (spit "/tmp/ornament.css" (defined-styles))
-  )
-      (->> @rules-registry
-           vals
-           (sort-by :index)
-           (mapcat :rules)
-           process-rules)
+
+  (->> @rules-registry
+       vals
+       (sort-by :index)
+       (mapcat :rules)
+       process-rules))
+

--- a/src/lambdaisland/ornament.cljc
+++ b/src/lambdaisland/ornament.cljc
@@ -834,7 +834,7 @@
       (mapcat
        identity
        (for [[tname tdef] tokens]
-         (let [tname (str prefix (str/replace tname #"^--" ""))
+         (let [tname (str prefix tname)
                {:strs [$description $value $type]} tdef
                more (into {} (remove (fn [[k v]] (= (first k) \$))) tdef)]
            (cond-> [`(defprop ~(symbol tname) ~@(when $description [$description]) ~$value)]
@@ -855,7 +855,7 @@
                        vals
                        (filter (comp some? :value)))]
         (when (seq props)
-          [[":root" (into {}
+          [[":where(html)" (into {}
                           (map (juxt (comp (partial str "--") :propname)
                                      :value))
                           props)]]))

--- a/test/lambdaisland/ornament_test.cljc
+++ b/test/lambdaisland/ornament_test.cljc
@@ -164,6 +164,17 @@
 (o/defstyled heading-2-nest :h2
   [:& heading-1-nest :text-2xl])
 
+(o/defstyled with-doc :div
+  "A documented component")
+
+(o/defstyled with-doc2 :div
+  "A documented component"
+  :mx-2 {:color "blue"})
+
+(o/defstyled with-doc3 :div
+  "A documented component"
+  ([]
+   [:<> "hello"]))
 
 #?(:clj
    (deftest css-test
@@ -417,7 +428,7 @@
            (o/defstyled ~'more-styles :span
              :rounded-xl)))
 
-       (is (= ".ot__my_styles{color:red}\n.ot__more_styles{border-radius:.75rem}"
+       (is (= ".ot__my_styles{color:red}.ot__more_styles{border-radius:.75rem}"
               (o/defined-styles)))
 
        (reset! o/registry reg))))
@@ -446,6 +457,17 @@
    (deftest component-resolution-inside-set
      (is (= ".ot__parent_set .ot__child_2,.ot__parent_set .ot__child_1{--gi-bg-opacity:1;background-color:rgba(21,128,61,var(--gi-bg-opacity))}"
             (o/css parent-set)))))
+
+(deftest docstring-test
+  (is (= "A documented component" (:doc (meta #'with-doc))))
+  (is (= "A documented component" (:doc (meta #'with-doc2))))
+  (is (= "A documented component" (:doc (meta #'with-doc3))))
+
+  (is (= '([] [& children] [attrs & children])
+         (:arglists (meta #'combined))))
+
+  (is (= '([{:keys [date time]}])
+         (:arglists (meta #'timed)))))
 
 (comment
   (require 'kaocha.repl)

--- a/test/lambdaisland/ornament_test.cljc
+++ b/test/lambdaisland/ornament_test.cljc
@@ -1,4 +1,4 @@
-(ns ^{:ornament/prefix "ot"}
+(ns ^{:ornament/prefix "ot__"}
     lambdaisland.ornament-test
   (:require [lambdaisland.ornament :as o]
             [clojure.test :refer [deftest testing is are use-fixtures run-tests join-fixtures]]


### PR DESCRIPTION
From the changelog

## Changed

- [BREAKING] When setting a custom `:ornament/prefix` on the namespace, the
  separator `__` is no longer implied, to get the same result add `__` to the
  end of your prefix string.

## Added

- If there's only a zero-arg render function (fn-tail), also emit a one-arg
  version that takes HTML attributes to be merged in.
- Add `defrules`, for general garden CSS rules
- Add `defprop`, for CSS custom properties (aka variables)
- Add `defutil`, for standalone utility classes
- Add `import-tokens!`, for importing W3C design token JSON files as properties (as per `defprop`)
- Allow setting metadata on a child list, useful for reagent/react keys

## Fixed

- Use of `defrules` in pure-cljs namespaces
- Fix implementation of ILookup on cljs