### PR TITLE
Laurence/clj kondo config

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,0 +1,3 @@
+{:lint-as {lambdaisland.ornament/defprop clojure.core/def
+           lambdaisland.ornament/defrules clojure.core/def}
+ :hooks {:analyze-call {lambdaisland.ornament/defstyled hooks.ornament/defstyled}}}

--- a/.clj-kondo/hooks/ornament.clj
+++ b/.clj-kondo/hooks/ornament.clj
@@ -1,0 +1,42 @@
+(ns hooks.ornament
+  (:require [clj-kondo.hooks-api :as api]))
+
+(defn defstyled [{:keys [node]}]
+  (let [[class-name html-tag & more] (rest (:children node))
+        _ (when-not (and (api/token-node? class-name)
+                         (simple-symbol? (api/sexpr class-name)))
+            (api/reg-finding! {:row (:row (meta class-name))
+                               :col (:col (meta class-name))
+                               :message "Style name must be a symbol"
+                               :type :lambdaisland.ornament/invalid-syntax}))
+        ; _ (prn :class-name class-name)
+        _ (when-not (api/keyword-node? html-tag)
+            (api/reg-finding! {:row (:row (meta html-tag))
+                               :col (:col (meta html-tag))
+                               :message "Html-tag must be a keyword"
+                               :type :lambdaisland.ornament/invalid-syntax}))
+        ; _ (prn :html-tag html-tag)
+        ; _ (prn :more more)
+        fn-tag (first (drop-while (fn [x]
+                                    (or (api/keyword-node? x)
+                                        (api/map-node? x)
+                                        (api/vector-node? x)))
+                                  more))
+        _ (prn :fn-tag fn-tag)
+        _ (when (or (api/list-node? fn-tag)
+                    (nil? fn-tag))
+            (api/reg-finding! {:row (:row (meta fn-tag))
+                               :col (:col (meta fn-tag))
+                               :message "fn-tag must be at least a list or nil"
+                               :type :lambdaisland.ornament/invalid-syntax}))]
+    (if (api/list-node? fn-tag)
+      (let [[binding-vec & body] (:children fn-tag)
+            new-node (api/list-node
+                      (list*
+                       (api/token-node 'fn)
+                       binding-vec
+                       body))]
+        (prn :new-node (api/sexpr new-node))
+        {:node new-node})
+     ;; nil node
+      {:node true})))

--- a/README.md
+++ b/README.md
@@ -943,6 +943,14 @@ And get a bullet list which uses bear emojis for the bullets.
 Girouette provides. You can change that by adding a `^:replace` tag (this uses
 meta-merge). e.g. `{:colors ^:replace {...}}`) 
 
+## clj-kondo Support
+
+This library includes a built-in clj-kondo configuration to improve linting for Ornament components.
+
+To use the configuration, simply copy the .clj-kondo/ directory from this repository into the root of your project.
+
+After copying the directory, clj-kondo will automatically use this configuration to provide more accurate linting and reduce false positives in your Ornament projects.
+
 ## Babashka compatibility
 
 Unfortunately Ornament is not bb-compatible, and most likely never will be.


### PR DESCRIPTION
Currently, only very simple implementation: 

- let the `defprop`, `defrules` be like `def`
- However, defstyled can be further improved. 
